### PR TITLE
Fix finding the uap prefix

### DIFF
--- a/template/cordova/lib/AppxManifest.js
+++ b/template/cordova/lib/AppxManifest.js
@@ -129,8 +129,7 @@ AppxManifest.get = function (fileName, ignoreCache) {
         }, []).sort();
 
     var prefix = prefixes[prefixes.length - 1];
-    var Manifest = prefix === 'uap' ? Win10AppxManifest : AppxManifest;
-    var result = new Manifest(fileName, prefix);
+    var result = prefixes.indexOf('uap') !== -1 ? new Win10AppxManifest(fileName) : new AppxManifest(fileName, prefix);
 
     if (!ignoreCache) {
         manifestCache[fileName] = result;


### PR DESCRIPTION
It was assumed that the uap prefix would always be in the same place. This doesn't hold if you end up modifying the package element. I've changed it so that it just checks for the existence of the prefix in the array of indexes.